### PR TITLE
[feat] 공통 에러 처리 셋팅 

### DIFF
--- a/src/main/java/ceos/backend/domain/example/ExampleController.java
+++ b/src/main/java/ceos/backend/domain/example/ExampleController.java
@@ -1,6 +1,7 @@
 package ceos.backend.domain.example;
 
 
+import ceos.backend.domain.example.exception.ExampleNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,6 +32,21 @@ public class ExampleController {
 
     @DeleteMapping(value = "/responseDelete")
     public int responseDelete() {
+        return 1;
+    }
+
+    @GetMapping(value = "/exampleError")
+    public int exampleError() {
+        throw ExampleNotFoundException.EXCEPTION;
+    }
+
+    @GetMapping(value = "/globalError")
+    public int globalError() {
+        throw new RuntimeException();
+    }
+
+    @GetMapping(value = "/globalError2")
+    public int globalError2(@RequestParam(name = "a") int a) {
         return 1;
     }
 }

--- a/src/main/java/ceos/backend/domain/example/exception/ExampleErrorCode.java
+++ b/src/main/java/ceos/backend/domain/example/exception/ExampleErrorCode.java
@@ -1,0 +1,26 @@
+package ceos.backend.domain.example.exception;
+
+import ceos.backend.global.common.dto.ErrorReason;
+import ceos.backend.global.error.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Getter
+@AllArgsConstructor
+public enum ExampleErrorCode implements BaseErrorCode {
+    EXAMPLE_NOT_FOUND(NOT_FOUND, "EXAMPLE_404_1", "예시를 찾을 수 없는 오류입니다."),
+    ;
+
+    private HttpStatus status;
+    private String code;
+    private String reason;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return ErrorReason.from(status.value(), code, reason);
+
+    }
+}

--- a/src/main/java/ceos/backend/domain/example/exception/ExampleNotFoundException.java
+++ b/src/main/java/ceos/backend/domain/example/exception/ExampleNotFoundException.java
@@ -1,0 +1,12 @@
+package ceos.backend.domain.example.exception;
+
+import ceos.backend.global.error.BaseErrorException;
+
+public class ExampleNotFoundException extends BaseErrorException {
+
+    public static final ExampleNotFoundException EXCEPTION = new ExampleNotFoundException();
+
+    private ExampleNotFoundException() {
+        super(ExampleErrorCode.EXAMPLE_NOT_FOUND);
+    }
+}

--- a/src/main/java/ceos/backend/global/common/dto/ErrorReason.java
+++ b/src/main/java/ceos/backend/global/common/dto/ErrorReason.java
@@ -1,0 +1,26 @@
+package ceos.backend.global.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ErrorReason {
+    private final Integer status;
+    private final String code;
+    private final String reason;
+
+    @Builder
+    private ErrorReason(Integer status, String code, String reason) {
+        this.status = status;
+        this.code = code;
+        this.reason = reason;
+    }
+
+    public static ErrorReason from(Integer status, String code, String reason) {
+        return ErrorReason.builder()
+                .status(status)
+                .code(code)
+                .reason(reason)
+                .build();
+    }
+}

--- a/src/main/java/ceos/backend/global/error/BaseErrorCode.java
+++ b/src/main/java/ceos/backend/global/error/BaseErrorCode.java
@@ -1,0 +1,7 @@
+package ceos.backend.global.error;
+
+import ceos.backend.global.common.dto.ErrorReason;
+
+public interface BaseErrorCode {
+    public ErrorReason getErrorReason();
+}

--- a/src/main/java/ceos/backend/global/error/BaseErrorException.java
+++ b/src/main/java/ceos/backend/global/error/BaseErrorException.java
@@ -1,0 +1,15 @@
+package ceos.backend.global.error;
+
+import ceos.backend.global.common.dto.ErrorReason;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BaseErrorException extends RuntimeException {
+    private BaseErrorCode errorCode;
+
+    public ErrorReason getErrorReason() {
+        return this.errorCode.getErrorReason();
+    }
+}

--- a/src/main/java/ceos/backend/global/error/ErrorResponse.java
+++ b/src/main/java/ceos/backend/global/error/ErrorResponse.java
@@ -1,0 +1,32 @@
+package ceos.backend.global.error;
+
+import ceos.backend.global.common.dto.ErrorReason;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+public class ErrorResponse {
+    private final String timestamp = LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME);
+    private final boolean success = false;
+    private String code;
+    private String status;
+    private String reason;
+
+    @Builder
+    private ErrorResponse(String code, String status, String reason) {
+        this.code = code;
+        this.status = status;
+        this.reason = reason;
+    }
+
+    public static ErrorResponse of(ErrorReason errorReason) {
+        return ErrorResponse.builder()
+                .code(errorReason.getCode())
+                .status(errorReason.getStatus().toString())
+                .reason(errorReason.getReason())
+                .build();
+    }
+}

--- a/src/main/java/ceos/backend/global/error/GlobalErrorCode.java
+++ b/src/main/java/ceos/backend/global/error/GlobalErrorCode.java
@@ -5,12 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Getter
 @AllArgsConstructor
 public enum GlobalErrorCode implements BaseErrorCode{
 
+    _INTERNAL_SERVER_ERROR(INTERNAL_SERVER_ERROR, "GLOBAL_500_1", "서버 오류. 관리자에게 문의 부탁드립니다."),
     EXAMPLE_GLOBAL_NOT_FOUND(NOT_FOUND, "EXAMPLEGLOBAL_404_1", "예시를 찾을 수 없는 오류입니다."),
     ;
 

--- a/src/main/java/ceos/backend/global/error/GlobalErrorCode.java
+++ b/src/main/java/ceos/backend/global/error/GlobalErrorCode.java
@@ -1,0 +1,25 @@
+package ceos.backend.global.error;
+
+import ceos.backend.global.common.dto.ErrorReason;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Getter
+@AllArgsConstructor
+public enum GlobalErrorCode implements BaseErrorCode{
+
+    EXAMPLE_GLOBAL_NOT_FOUND(NOT_FOUND, "EXAMPLEGLOBAL_404_1", "예시를 찾을 수 없는 오류입니다."),
+    ;
+
+    private HttpStatus status;
+    private String code;
+    private String reason;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return ErrorReason.from(status.value(), code, reason);
+    }
+}

--- a/src/main/java/ceos/backend/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/ceos/backend/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,55 @@
+package ceos.backend.global.error;
+
+import ceos.backend.global.common.dto.ErrorReason;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(
+            Exception ex,
+            @Nullable Object body,
+            HttpHeaders headers,
+            HttpStatusCode statusCode,
+            WebRequest request) {
+        log.error("HandleInternalException", ex);
+        final HttpStatus status = (HttpStatus) statusCode;
+        final ErrorReason errorReason = ErrorReason.from(status.value(), status.name(), ex.getMessage());
+        final ErrorResponse errorResponse = ErrorResponse.of(errorReason);
+        return super.handleExceptionInternal(ex, errorResponse, headers, status, request);
+    }
+
+    // 비즈니스 로직 에러 처리
+    @ExceptionHandler(BaseErrorException.class)
+    public ResponseEntity<ErrorResponse> handleBaseErrorException(BaseErrorException e, HttpServletRequest request) {
+        log.error("BaseErrorException", e);
+        final ErrorReason errorReason = e.getErrorCode().getErrorReason();
+        final ErrorResponse errorResponse = ErrorResponse.of(errorReason);
+        return ResponseEntity.status(HttpStatus.valueOf(errorReason.getStatus()))
+                .body(errorResponse);
+    }
+
+    // 위에서 따로 처리하지 않은 에러를 모두 처리해줍니다.
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
+        log.error("Exception", e);
+        final GlobalErrorCode globalErrorCode = GlobalErrorCode._INTERNAL_SERVER_ERROR;
+        final ErrorReason errorReason = globalErrorCode.getErrorReason();
+        final ErrorResponse errorResponse = ErrorResponse.of(errorReason);
+        return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+}

--- a/src/main/java/ceos/backend/global/error/exception/ExampleGlobalNotFoundException.java
+++ b/src/main/java/ceos/backend/global/error/exception/ExampleGlobalNotFoundException.java
@@ -1,0 +1,13 @@
+package ceos.backend.global.error.exception;
+
+import ceos.backend.global.error.BaseErrorException;
+import ceos.backend.global.error.GlobalErrorCode;
+
+public class ExampleGlobalNotFoundException extends BaseErrorException {
+
+    public static final BaseErrorException EXCEPTION = new ExampleGlobalNotFoundException();
+
+    private ExampleGlobalNotFoundException() {
+        super(GlobalErrorCode.EXAMPLE_GLOBAL_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
# 💡 PR Summary - [feat] 공통 에러 처리 셋팅 
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
공통 에러 처리 셋팅했습니다.
작성한 exception을 이용하여 error를 발생시키면, global exception handler를 통해 처리되도록 구현했습니다.


error code는 이런 식으로 구현하면 됩니다. 
<img width="749" alt="스크린샷 2023-05-05 오후 8 28 27" src="https://user-images.githubusercontent.com/67852689/236446267-ae1a88b7-ca3e-4b3f-ab46-03a9d0c77b0b.png">
baseErrorCode의 구현체입니다.
error code 파일은 도메인마다 작성해야 합니다.
enum은 extends 가 불가능해서, 아랫부분의 코드는 error code 파일마다 작성해야 합니다.
위쪽에 enum만 추가하면 됩니다.
이렇게 추가한 error code는 아래 error exception에서 사용하게 됩니다.


error exception은 이런 식으로 구현하면 됩니다.
<img width="759" alt="스크린샷 2023-05-05 오후 8 28 58" src="https://user-images.githubusercontent.com/67852689/236446365-1f1fb475-7252-4216-a9ec-f41c64e56403.png">
baseErrorException을 상속받아서 구현합니다.
error code마다 error exception을 작성해서 사용하시면 됩니다.



구현한 exception은 이런 식으로 사용하면 됩니다.
<img width="621" alt="스크린샷 2023-05-05 오후 8 34 03" src="https://user-images.githubusercontent.com/67852689/236447304-69d875f1-a841-4e92-9637-45c11b33494f.png">
exception의 static 부분을 throw 하면 됩니다.

+ 레포 watch 설정해두면 풀리퀘 올렸을 때 메일 옵니다!


### 🌲 Working Branch

---
<!-- 예시) feature/user -->
feat/error

### 📖 Related Issues

---
<!-- 예시) #1 -->
- close #2

