### PR TITLE
[fix] award 페이지에서 max generation 찾을때 project 기준으로 찾기

### DIFF
--- a/src/main/java/ceos/backend/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/ceos/backend/domain/project/repository/ProjectRepository.java
@@ -11,7 +11,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     Optional<Project> findByNameAndGeneration(String name, int generation);
     List<Project> findByGeneration(int generation);
 
-    @Query("SELECT MAX(a.generation) FROM Project a")
+    @Query("SELECT MAX(p.generation) FROM Project p")
     int findMaxGeneration();
 
 }

--- a/src/main/java/ceos/backend/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/ceos/backend/domain/project/repository/ProjectRepository.java
@@ -11,7 +11,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     Optional<Project> findByNameAndGeneration(String name, int generation);
     List<Project> findByGeneration(int generation);
 
-    @Query("SELECT MAX(a.generation) FROM Awards a")
+    @Query("SELECT MAX(a.generation) FROM Project a")
     int findMaxGeneration();
 
 }


### PR DESCRIPTION
# 💡 PR Summary - award 페이지에서 max generation 찾을때 project 기준으로 찾기
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
award 페이지에서 max generation 찾을때 project 기준으로 찾도록 수정했습니다
- max generation부터 각 기수의 project와 awards를 보여줌 
- 수상 내역 없는 최근 기수까지 보여주려면 project를 기준으로 찾아야

(ProjectRepository 안에 만들어놓고 쓰다가 실수를 했던 것 같네욤)

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
작업 브랜치
fix/awards

### 📖 Related Issues

---
<!-- 예시) #1 -->
이슈 번호
- close #

