### PR TITLE
[refact] 기수 활동시기 테이블 분리

### DIFF
--- a/src/main/java/ceos/backend/domain/application/dto/response/GetResultResponse.java
+++ b/src/main/java/ceos/backend/domain/application/dto/response/GetResultResponse.java
@@ -7,10 +7,9 @@ import ceos.backend.domain.recruitment.domain.Recruitment;
 import ceos.backend.global.common.dto.ParsedDuration;
 import ceos.backend.global.util.ParsedDurationConvertor;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.time.LocalDate;
 
 @Getter
 public class GetResultResponse {

--- a/src/main/java/ceos/backend/domain/application/exception/NotSetInterviewTime.java
+++ b/src/main/java/ceos/backend/domain/application/exception/NotSetInterviewTime.java
@@ -5,8 +5,7 @@ import ceos.backend.global.error.BaseErrorException;
 
 public class NotSetInterviewTime extends BaseErrorException {
 
-    public static final NotSetInterviewTime EXCEPTION =
-            new NotSetInterviewTime();
+    public static final NotSetInterviewTime EXCEPTION = new NotSetInterviewTime();
 
     private NotSetInterviewTime() {
         super(ApplicationErrorCode.NOT_SET_INTERVIEW_TIME);

--- a/src/main/java/ceos/backend/domain/application/validator/ApplicationValidator.java
+++ b/src/main/java/ceos/backend/domain/application/validator/ApplicationValidator.java
@@ -109,12 +109,13 @@ public class ApplicationValidator {
     }
 
     public void validateInterviewTimeExist(String uuid, String email) {
-        Application application = applicationRepository
-                .findByUuidAndEmail(uuid, email)
-                .orElseThrow(
-                        () -> {
-                            throw ApplicantNotFound.EXCEPTION;
-                        });
+        Application application =
+                applicationRepository
+                        .findByUuidAndEmail(uuid, email)
+                        .orElseThrow(
+                                () -> {
+                                    throw ApplicantNotFound.EXCEPTION;
+                                });
         if (application.getInterviewDatetime() == null) {
             throw NotSetInterviewTime.EXCEPTION;
         }

--- a/src/main/java/ceos/backend/domain/awards/AwardsController.java
+++ b/src/main/java/ceos/backend/domain/awards/AwardsController.java
@@ -8,7 +8,6 @@ import ceos.backend.domain.awards.service.AwardsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/ceos/backend/domain/awards/AwardsController.java
+++ b/src/main/java/ceos/backend/domain/awards/AwardsController.java
@@ -24,7 +24,7 @@ public class AwardsController {
 
     @Operation(summary = "수상이력 추가하기")
     @PostMapping
-    public void createAwards(@RequestBody @Valid List<AwardsRequest> awardsRequest) {
+    public void createAwards(@RequestBody @Valid AwardsRequest awardsRequest) {
         log.info("수상이력 추가하기");
         awardsService.createAwards(awardsRequest);
     }
@@ -49,7 +49,7 @@ public class AwardsController {
     @PutMapping("/{generation}")
     public void updateAwards(
             @PathVariable(name = "generation") int generation,
-            @RequestBody List<AwardsRequest> awardsRequest) {
+            @RequestBody AwardsRequest awardsRequest) {
         log.info("수상이력 수정하기");
         awardsService.updateAwards(generation, awardsRequest);
     }

--- a/src/main/java/ceos/backend/domain/awards/domain/Awards.java
+++ b/src/main/java/ceos/backend/domain/awards/domain/Awards.java
@@ -24,28 +24,19 @@ public class Awards {
     @Size(max = 100)
     private String content;
 
-    @NotNull private LocalDate startDate;
-
     // 생성자
     @Builder
-    private Awards(int generation, String content, LocalDate startDate) {
+    private Awards(int generation, String content) {
         this.generation = generation;
         this.content = content;
-        this.startDate = startDate;
     }
 
     // 정적 팩토리 메서드
-    public static Awards from(AwardsRequest awardsRequest) {
+    public static Awards of(int generation, String content) {
         return Awards.builder()
-                .generation(awardsRequest.getGeneration())
-                .content(awardsRequest.getContent())
-                .startDate(awardsRequest.getStartDate())
+                .generation(generation)
+                .content(content)
                 .build();
     }
 
-    public void updateAward(AwardsRequest awardsRequest) {
-        this.generation = awardsRequest.getGeneration();
-        this.content = awardsRequest.getContent();
-        this.startDate = awardsRequest.getStartDate();
-    }
 }

--- a/src/main/java/ceos/backend/domain/awards/domain/Awards.java
+++ b/src/main/java/ceos/backend/domain/awards/domain/Awards.java
@@ -1,11 +1,9 @@
 package ceos.backend.domain.awards.domain;
 
 
-import ceos.backend.domain.awards.dto.request.AwardsRequest;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import java.time.LocalDate;
 import lombok.*;
 
 @Getter
@@ -33,10 +31,6 @@ public class Awards {
 
     // 정적 팩토리 메서드
     public static Awards of(int generation, String content) {
-        return Awards.builder()
-                .generation(generation)
-                .content(content)
-                .build();
+        return Awards.builder().generation(generation).content(content).build();
     }
-
 }

--- a/src/main/java/ceos/backend/domain/awards/domain/StartDate.java
+++ b/src/main/java/ceos/backend/domain/awards/domain/StartDate.java
@@ -1,0 +1,40 @@
+package ceos.backend.domain.awards.domain;
+
+import ceos.backend.domain.awards.dto.request.AwardsRequest;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class StartDate {
+
+    @Id
+    private int generation;
+
+    @NotNull
+    private LocalDate startDate;
+
+    // 생성자
+    @Builder
+    public StartDate(int generation, LocalDate startDate) {
+        this.generation = generation;
+        this.startDate = startDate;
+    }
+
+    // 정적 팩토리 메서드
+    public static StartDate from(AwardsRequest awardsRequest) {
+        return StartDate.builder()
+                .generation(awardsRequest.getGeneration())
+                .startDate(awardsRequest.getStartDate())
+                .build();
+    }
+
+}

--- a/src/main/java/ceos/backend/domain/awards/domain/StartDate.java
+++ b/src/main/java/ceos/backend/domain/awards/domain/StartDate.java
@@ -3,7 +3,6 @@ package ceos.backend.domain.awards.domain;
 import ceos.backend.domain.awards.dto.request.AwardsRequest;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -35,6 +34,10 @@ public class StartDate {
                 .generation(awardsRequest.getGeneration())
                 .startDate(awardsRequest.getStartDate())
                 .build();
+    }
+
+    public void updateStartDate(LocalDate startDate){
+        this.startDate = startDate;
     }
 
 }

--- a/src/main/java/ceos/backend/domain/awards/domain/StartDate.java
+++ b/src/main/java/ceos/backend/domain/awards/domain/StartDate.java
@@ -1,25 +1,23 @@
 package ceos.backend.domain.awards.domain;
 
+
 import ceos.backend.domain.awards.dto.request.AwardsRequest;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class StartDate {
 
-    @Id
-    private int generation;
+    @Id private int generation;
 
-    @NotNull
-    private LocalDate startDate;
+    @NotNull private LocalDate startDate;
 
     // 생성자
     @Builder
@@ -36,8 +34,7 @@ public class StartDate {
                 .build();
     }
 
-    public void updateStartDate(LocalDate startDate){
+    public void updateStartDate(LocalDate startDate) {
         this.startDate = startDate;
     }
-
 }

--- a/src/main/java/ceos/backend/domain/awards/dto/request/AwardsRequest.java
+++ b/src/main/java/ceos/backend/domain/awards/dto/request/AwardsRequest.java
@@ -6,9 +6,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.List;
-
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/ceos/backend/domain/awards/dto/request/AwardsRequest.java
+++ b/src/main/java/ceos/backend/domain/awards/dto/request/AwardsRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
 
 import lombok.Builder;
@@ -23,7 +24,7 @@ public class AwardsRequest {
     @Valid
     private LocalDate startDate;
 
-    @Schema(defaultValue = "2023 예비창업패키지 최종선정", description = "수상 기록")
+    @Schema(description = "수상 기록 리스트")
     @NotEmpty(message = "수상 기록을 입력해주세요")
     @Valid
     private List<String> content;

--- a/src/main/java/ceos/backend/domain/awards/dto/request/AwardsRequest.java
+++ b/src/main/java/ceos/backend/domain/awards/dto/request/AwardsRequest.java
@@ -6,6 +6,8 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.util.List;
+
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,28 +18,28 @@ public class AwardsRequest {
     @Valid
     private int generation;
 
-    @Schema(defaultValue = "2023 예비창업패키지 최종선정", description = "수상 기록")
-    @NotEmpty(message = "수상 기록을 입력해주세요")
-    @Valid
-    private String content;
-
     @Schema(description = "활동 시작 시기")
     @NotNull(message = "활동 시작 시기를 입력해주세요")
     @Valid
     private LocalDate startDate;
 
+    @Schema(defaultValue = "2023 예비창업패키지 최종선정", description = "수상 기록")
+    @NotEmpty(message = "수상 기록을 입력해주세요")
+    @Valid
+    private List<String> content;
+
     @Builder
-    private AwardsRequest(int generation, String content, LocalDate startDate) {
+    public AwardsRequest(int generation, LocalDate startDate, List<String> content) {
         this.generation = generation;
-        this.content = content;
         this.startDate = startDate;
+        this.content = content;
     }
 
-    public static AwardsRequest of(int generation, String content, LocalDate startDate) {
+    public static AwardsRequest of(int generation, LocalDate startDate, List<String> content) {
         return AwardsRequest.builder()
                 .generation(generation)
-                .content(content)
                 .startDate(startDate)
+                .content(content)
                 .build();
     }
 }

--- a/src/main/java/ceos/backend/domain/awards/dto/response/AwardsResponse.java
+++ b/src/main/java/ceos/backend/domain/awards/dto/response/AwardsResponse.java
@@ -11,20 +11,17 @@ public class AwardsResponse {
 
     private Long id;
     private String content;
-    private LocalDate startDate;
 
     @Builder
-    private AwardsResponse(Long id, String content, LocalDate startDate) {
+    private AwardsResponse(Long id, String content) {
         this.id = id;
         this.content = content;
-        this.startDate = startDate;
     }
 
     public static AwardsResponse to(Awards awards) {
         return AwardsResponse.builder()
                 .id(awards.getId())
                 .content(awards.getContent())
-                .startDate(awards.getStartDate())
                 .build();
     }
 }

--- a/src/main/java/ceos/backend/domain/awards/dto/response/AwardsResponse.java
+++ b/src/main/java/ceos/backend/domain/awards/dto/response/AwardsResponse.java
@@ -2,7 +2,6 @@ package ceos.backend.domain.awards.dto.response;
 
 
 import ceos.backend.domain.awards.domain.Awards;
-import java.time.LocalDate;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -19,9 +18,6 @@ public class AwardsResponse {
     }
 
     public static AwardsResponse to(Awards awards) {
-        return AwardsResponse.builder()
-                .id(awards.getId())
-                .content(awards.getContent())
-                .build();
+        return AwardsResponse.builder().id(awards.getId()).content(awards.getContent()).build();
     }
 }

--- a/src/main/java/ceos/backend/domain/awards/dto/response/GenerationAwardsResponse.java
+++ b/src/main/java/ceos/backend/domain/awards/dto/response/GenerationAwardsResponse.java
@@ -2,6 +2,8 @@ package ceos.backend.domain.awards.dto.response;
 
 
 import ceos.backend.domain.awards.vo.ProjectInfoVo;
+
+import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,21 +11,24 @@ import lombok.Getter;
 @Getter
 public class GenerationAwardsResponse {
     private int generation;
+    private LocalDate startDate;
     private List<AwardsResponse> awards;
     private List<ProjectInfoVo> projects;
 
     @Builder
     public GenerationAwardsResponse(
-            int generation, List<AwardsResponse> awards, List<ProjectInfoVo> projects) {
+            int generation, LocalDate startDate, List<AwardsResponse> awards, List<ProjectInfoVo> projects) {
         this.generation = generation;
+        this.startDate = startDate;
         this.awards = awards;
         this.projects = projects;
     }
 
     public static GenerationAwardsResponse of(
-            int generation, List<AwardsResponse> awards, List<ProjectInfoVo> projects) {
+            int generation, LocalDate startDate, List<AwardsResponse> awards, List<ProjectInfoVo> projects) {
         return GenerationAwardsResponse.builder()
                 .generation(generation)
+                .startDate(startDate)
                 .awards(awards)
                 .projects(projects)
                 .build();

--- a/src/main/java/ceos/backend/domain/awards/dto/response/GenerationAwardsResponse.java
+++ b/src/main/java/ceos/backend/domain/awards/dto/response/GenerationAwardsResponse.java
@@ -2,7 +2,6 @@ package ceos.backend.domain.awards.dto.response;
 
 
 import ceos.backend.domain.awards.vo.ProjectInfoVo;
-
 import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
@@ -17,7 +16,10 @@ public class GenerationAwardsResponse {
 
     @Builder
     public GenerationAwardsResponse(
-            int generation, LocalDate startDate, List<AwardsResponse> awards, List<ProjectInfoVo> projects) {
+            int generation,
+            LocalDate startDate,
+            List<AwardsResponse> awards,
+            List<ProjectInfoVo> projects) {
         this.generation = generation;
         this.startDate = startDate;
         this.awards = awards;
@@ -25,7 +27,10 @@ public class GenerationAwardsResponse {
     }
 
     public static GenerationAwardsResponse of(
-            int generation, LocalDate startDate, List<AwardsResponse> awards, List<ProjectInfoVo> projects) {
+            int generation,
+            LocalDate startDate,
+            List<AwardsResponse> awards,
+            List<ProjectInfoVo> projects) {
         return GenerationAwardsResponse.builder()
                 .generation(generation)
                 .startDate(startDate)

--- a/src/main/java/ceos/backend/domain/awards/exception/AwardsErrorCode.java
+++ b/src/main/java/ceos/backend/domain/awards/exception/AwardsErrorCode.java
@@ -11,7 +11,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum AwardsErrorCode implements BaseErrorCode {
-    AWARD_NOT_FOUND(BAD_REQUEST, "AWARD_404_1", "해당 수상이력이 존재하지 않습니다");
+    AWARD_NOT_FOUND(BAD_REQUEST, "AWARD_404_1", "해당 수상이력이 존재하지 않습니다"),
+    START_DATE_NOT_FOUND(BAD_REQUEST, "AWARD_404_2", "해당 기수의 활동 시작 시기 정보가 존재하지 않습니다");
 
     private HttpStatus status;
     private String code;

--- a/src/main/java/ceos/backend/domain/awards/exception/StartDateNotFound.java
+++ b/src/main/java/ceos/backend/domain/awards/exception/StartDateNotFound.java
@@ -1,5 +1,6 @@
 package ceos.backend.domain.awards.exception;
 
+
 import ceos.backend.global.error.BaseErrorException;
 
 public class StartDateNotFound extends BaseErrorException {

--- a/src/main/java/ceos/backend/domain/awards/exception/StartDateNotFound.java
+++ b/src/main/java/ceos/backend/domain/awards/exception/StartDateNotFound.java
@@ -1,0 +1,11 @@
+package ceos.backend.domain.awards.exception;
+
+import ceos.backend.global.error.BaseErrorException;
+
+public class StartDateNotFound extends BaseErrorException {
+    public static final StartDateNotFound EXCEPTION = new StartDateNotFound();
+
+    private StartDateNotFound() {
+        super(AwardsErrorCode.START_DATE_NOT_FOUND);
+    }
+}

--- a/src/main/java/ceos/backend/domain/awards/helper/AwardsHelper.java
+++ b/src/main/java/ceos/backend/domain/awards/helper/AwardsHelper.java
@@ -7,6 +7,8 @@ import ceos.backend.domain.awards.repository.AwardsRepository;
 import ceos.backend.domain.awards.vo.ProjectInfoVo;
 import ceos.backend.domain.project.domain.Project;
 import ceos.backend.domain.project.repository.ProjectRepository;
+
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/ceos/backend/domain/awards/helper/AwardsHelper.java
+++ b/src/main/java/ceos/backend/domain/awards/helper/AwardsHelper.java
@@ -7,8 +7,6 @@ import ceos.backend.domain.awards.repository.AwardsRepository;
 import ceos.backend.domain.awards.vo.ProjectInfoVo;
 import ceos.backend.domain.project.domain.Project;
 import ceos.backend.domain.project.repository.ProjectRepository;
-
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/ceos/backend/domain/awards/repository/StartDateRepository.java
+++ b/src/main/java/ceos/backend/domain/awards/repository/StartDateRepository.java
@@ -1,7 +1,7 @@
 package ceos.backend.domain.awards.repository;
 
+
 import ceos.backend.domain.awards.domain.StartDate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StartDateRepository extends JpaRepository<StartDate, Integer> {
-}
+public interface StartDateRepository extends JpaRepository<StartDate, Integer> {}

--- a/src/main/java/ceos/backend/domain/awards/repository/StartDateRepository.java
+++ b/src/main/java/ceos/backend/domain/awards/repository/StartDateRepository.java
@@ -1,0 +1,7 @@
+package ceos.backend.domain.awards.repository;
+
+import ceos.backend.domain.awards.domain.StartDate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StartDateRepository extends JpaRepository<StartDate, Integer> {
+}

--- a/src/main/java/ceos/backend/domain/awards/service/AwardsService.java
+++ b/src/main/java/ceos/backend/domain/awards/service/AwardsService.java
@@ -12,7 +12,6 @@ import ceos.backend.domain.awards.repository.AwardsRepository;
 import ceos.backend.domain.awards.repository.StartDateRepository;
 import ceos.backend.domain.project.repository.ProjectRepository;
 import ceos.backend.global.common.dto.PageInfo;
-
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,10 +50,20 @@ public class AwardsService {
 
         int maxGeneration = projectRepository.findMaxGeneration();
         for (int i = maxGeneration; i > 0; i--) {
-            LocalDate startDate = startDateRepository.findById(i).orElseThrow(() -> {throw StartDateNotFound.EXCEPTION;}).getStartDate();
+            LocalDate startDate =
+                    startDateRepository
+                            .findById(i)
+                            .orElseThrow(
+                                    () -> {
+                                        throw StartDateNotFound.EXCEPTION;
+                                    })
+                            .getStartDate();
             GenerationAwardsResponse generationAwardsResponse =
                     GenerationAwardsResponse.of(
-                            i, startDate, awardsHelper.getAwardsDto(i), awardsHelper.getProjectVo(i));
+                            i,
+                            startDate,
+                            awardsHelper.getAwardsDto(i),
+                            awardsHelper.getProjectVo(i));
             generationAwardsResponses.add(generationAwardsResponse);
         }
 
@@ -76,7 +85,14 @@ public class AwardsService {
 
     @Transactional(readOnly = true)
     public GenerationAwardsResponse getGenerationAwards(int generation) {
-        LocalDate startDate = startDateRepository.findById(generation).orElseThrow(() -> {throw StartDateNotFound.EXCEPTION;}).getStartDate();
+        LocalDate startDate =
+                startDateRepository
+                        .findById(generation)
+                        .orElseThrow(
+                                () -> {
+                                    throw StartDateNotFound.EXCEPTION;
+                                })
+                        .getStartDate();
         return GenerationAwardsResponse.of(
                 generation,
                 startDate,
@@ -90,7 +106,13 @@ public class AwardsService {
         deleteAwards(generation);
 
         // 활동시작시기 업데이트
-        StartDate startDate = startDateRepository.findById(generation).orElseThrow(() -> {throw StartDateNotFound.EXCEPTION;});
+        StartDate startDate =
+                startDateRepository
+                        .findById(generation)
+                        .orElseThrow(
+                                () -> {
+                                    throw StartDateNotFound.EXCEPTION;
+                                });
         startDate.updateStartDate(awardsRequest.getStartDate());
 
         // 수상 내역 저장


### PR DESCRIPTION
# 💡 PR Summary - 기수 활동시기 테이블 분리
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
- 기존: 기수의 start_date를 Awards의 필드로 저장
- 작업 후: Start Date 테이블 만들어 기수의 활동 시작 시기 저장 (Awards 화면에서 불러오거나 수정할때 Start Date 테이블 이용)
- 그에 맞게 awards api 수정했습니다

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
react/awards-3

### 📖 Related Issues

---
<!-- 예시) #1 -->
이슈 번호
- close #130

