### PR TITLE
[add] 기수 수상내역이 있을때 다시 추가시 에러처리

### DIFF
--- a/src/main/java/ceos/backend/domain/awards/exception/AwardsErrorCode.java
+++ b/src/main/java/ceos/backend/domain/awards/exception/AwardsErrorCode.java
@@ -1,6 +1,7 @@
 package ceos.backend.domain.awards.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
 
 import ceos.backend.global.common.dto.ErrorReason;
 import ceos.backend.global.error.BaseErrorCode;
@@ -12,7 +13,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AwardsErrorCode implements BaseErrorCode {
     AWARD_NOT_FOUND(BAD_REQUEST, "AWARD_404_1", "해당 수상이력이 존재하지 않습니다"),
-    START_DATE_NOT_FOUND(BAD_REQUEST, "AWARD_404_2", "해당 기수의 활동 시작 시기 정보가 존재하지 않습니다");
+    START_DATE_NOT_FOUND(BAD_REQUEST, "AWARD_404_2", "해당 기수의 활동 시작 시기 정보가 존재하지 않습니다"),
+    DUPLICATE_GENERATION(CONFLICT, "AWARD_409_1", "해당 기수의 데이터가 이미 존재합니다");
 
     private HttpStatus status;
     private String code;

--- a/src/main/java/ceos/backend/domain/awards/exception/DuplicateGeneration.java
+++ b/src/main/java/ceos/backend/domain/awards/exception/DuplicateGeneration.java
@@ -1,5 +1,6 @@
 package ceos.backend.domain.awards.exception;
 
+
 import ceos.backend.global.error.BaseErrorException;
 
 public class DuplicateGeneration extends BaseErrorException {

--- a/src/main/java/ceos/backend/domain/awards/exception/DuplicateGeneration.java
+++ b/src/main/java/ceos/backend/domain/awards/exception/DuplicateGeneration.java
@@ -1,0 +1,11 @@
+package ceos.backend.domain.awards.exception;
+
+import ceos.backend.global.error.BaseErrorException;
+
+public class DuplicateGeneration extends BaseErrorException {
+    public static final DuplicateGeneration EXCEPTION = new DuplicateGeneration();
+
+    private DuplicateGeneration() {
+        super(AwardsErrorCode.DUPLICATE_GENERATION);
+    }
+}

--- a/src/main/java/ceos/backend/domain/awards/helper/AwardsHelper.java
+++ b/src/main/java/ceos/backend/domain/awards/helper/AwardsHelper.java
@@ -13,7 +13,6 @@ import ceos.backend.domain.project.repository.ProjectRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -46,9 +45,9 @@ public class AwardsHelper {
         return awardsResponseList;
     }
 
-    public void validateGeneration(int generation){
+    public void validateGeneration(int generation) {
         Optional<StartDate> startDate = startDateRepository.findById(generation);
-        if(startDate.isPresent()){
+        if (startDate.isPresent()) {
             throw DuplicateGeneration.EXCEPTION;
         }
     }

--- a/src/main/java/ceos/backend/domain/awards/helper/AwardsHelper.java
+++ b/src/main/java/ceos/backend/domain/awards/helper/AwardsHelper.java
@@ -2,13 +2,18 @@ package ceos.backend.domain.awards.helper;
 
 
 import ceos.backend.domain.awards.domain.Awards;
+import ceos.backend.domain.awards.domain.StartDate;
 import ceos.backend.domain.awards.dto.response.AwardsResponse;
+import ceos.backend.domain.awards.exception.DuplicateGeneration;
 import ceos.backend.domain.awards.repository.AwardsRepository;
+import ceos.backend.domain.awards.repository.StartDateRepository;
 import ceos.backend.domain.awards.vo.ProjectInfoVo;
 import ceos.backend.domain.project.domain.Project;
 import ceos.backend.domain.project.repository.ProjectRepository;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -18,6 +23,7 @@ public class AwardsHelper {
 
     private final ProjectRepository projectRepository;
     private final AwardsRepository awardsRepository;
+    private final StartDateRepository startDateRepository;
 
     public List<ProjectInfoVo> getProjectVo(int generation) {
         List<Project> projectList = projectRepository.findByGeneration(generation);
@@ -38,5 +44,12 @@ public class AwardsHelper {
             awardsResponseList.add(awardsResponse);
         }
         return awardsResponseList;
+    }
+
+    public void validateGeneration(int generation){
+        Optional<StartDate> startDate = startDateRepository.findById(generation);
+        if(startDate.isPresent()){
+            throw DuplicateGeneration.EXCEPTION;
+        }
     }
 }

--- a/src/main/java/ceos/backend/domain/awards/service/AwardsService.java
+++ b/src/main/java/ceos/backend/domain/awards/service/AwardsService.java
@@ -32,8 +32,10 @@ public class AwardsService {
 
     @Transactional
     public void createAwards(AwardsRequest awardsRequest) {
-        // 활동 시작 시기 저장
+        // 이미 기수의 수상 정보가 있다면 다시 추가할 수 없음
         awardsHelper.validateGeneration(awardsRequest.getGeneration());
+
+        // 활동 시작 시기 저장
         StartDate startDate = StartDate.from(awardsRequest);
         startDateRepository.save(startDate);
 

--- a/src/main/java/ceos/backend/domain/awards/service/AwardsService.java
+++ b/src/main/java/ceos/backend/domain/awards/service/AwardsService.java
@@ -33,6 +33,7 @@ public class AwardsService {
     @Transactional
     public void createAwards(AwardsRequest awardsRequest) {
         // 활동 시작 시기 저장
+        awardsHelper.validateGeneration(awardsRequest.getGeneration());
         StartDate startDate = StartDate.from(awardsRequest);
         startDateRepository.save(startDate);
 


### PR DESCRIPTION
# 💡 PR Summary - 기수 수상내역이 있을때 다시 추가시 에러처리
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
기수 수상내역이 있을때 해당 기수로 다시 POST 요청을 보내면 에러처리를 합니다.
(기수 수상내역이 이미 존재할때 데이터를 수정하려면 화면의 추가버튼이 아니라 수정버튼을 통해서만 가능합니다.)

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
refact/awards-4


### 📖 Related Issues

---
<!-- 예시) #1 -->
이슈 번호
- close #130

