### PR TITLE
[feat] 지원 서류 삭제 기능

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hyunihs @suhhyun524 @mushroom1324 @haen-su @mirageoasis
+* @hyunihs @mushroom1324 @letskuku @yoonsseo @itsme-shawn @YoungGyo-00

--- a/src/main/java/ceos/backend/domain/application/ApplicationController.java
+++ b/src/main/java/ceos/backend/domain/application/ApplicationController.java
@@ -26,15 +26,7 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -190,5 +182,12 @@ public class ApplicationController {
     public GetCreationTime getApplicationExcelCreationTime() {
         log.info("지원서 엑셀 파일 생성 시각 확인");
         return applicationExcelService.getApplicationExcelCreationTime();
+    }
+
+    @Operation(summary = "지원서 전체 삭제")
+    @DeleteMapping(value = "/delete")
+    public void deleteAllApplications() {
+        log.info("지원서 전체 삭제");
+        applicationService.deleteAllApplications();
     }
 }

--- a/src/main/java/ceos/backend/domain/application/domain/ApplicationAnswer.java
+++ b/src/main/java/ceos/backend/domain/application/domain/ApplicationAnswer.java
@@ -17,7 +17,7 @@ public class ApplicationAnswer extends BaseEntity {
     private Long id;
 
     // Question : Answer = 1:1 (단방향)
-    @OneToOne(cascade = CascadeType.ALL)
+    @OneToOne
     @JoinColumn(name = "application_question_id")
     private ApplicationQuestion applicationQuestion;
 

--- a/src/main/java/ceos/backend/domain/application/exception/ApplicationErrorCode.java
+++ b/src/main/java/ceos/backend/domain/application/exception/ApplicationErrorCode.java
@@ -22,6 +22,7 @@ public enum ApplicationErrorCode implements BaseErrorCode {
     SAME_PASS_STATUS(BAD_REQUEST, "APPLICATION_400_7", "같은 상태로 변경할 수 없습니다."),
     NOT_SET_INTERVIEW_TIME(BAD_REQUEST, "APPLICATION_400_8", "면접 시간이 정해지지 않았습니다."),
     APPLICATION_STILL_EXIST(BAD_REQUEST, "APPLICATION_400_9", "기존 지원자 데이터가 남아있습니다."),
+    NOT_DELETABLE_DURING_RECRUITMENT(BAD_REQUEST, "APPLICATION_400_10", "최종 발표 전 지원자를 삭제할 수 없습니다."),
 
     APPLICANT_NOT_FOUND(BAD_REQUEST, "APPLICATION_404_3", "존재하지 않는 지원자입니다."),
 

--- a/src/main/java/ceos/backend/domain/application/exception/exceptions/NotDeletableDuringRecruitment.java
+++ b/src/main/java/ceos/backend/domain/application/exception/exceptions/NotDeletableDuringRecruitment.java
@@ -1,0 +1,12 @@
+package ceos.backend.domain.application.exception.exceptions;
+
+import ceos.backend.domain.application.exception.ApplicationErrorCode;
+import ceos.backend.global.error.BaseErrorException;
+
+public class NotDeletableDuringRecruitment extends BaseErrorException {
+    public static final NotDeletableDuringRecruitment EXCEPTION = new NotDeletableDuringRecruitment();
+
+    private NotDeletableDuringRecruitment() {
+        super(ApplicationErrorCode.NOT_DELETABLE_DURING_RECRUITMENT);
+    }
+}

--- a/src/main/java/ceos/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/ceos/backend/domain/recruitment/service/RecruitmentService.java
@@ -11,6 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -34,6 +36,7 @@ public class RecruitmentService {
     @Transactional
     public void updateRecruitment(RecruitmentDTO recruitmentDTO) {
         Recruitment recruitment = recruitmentHelper.takeRecruitment();
+        recruitment.validAmenablePeriod(LocalDateTime.now());
 
         // 객체 업데이트
         recruitment.updateRecruitment(recruitmentDTO);


### PR DESCRIPTION
# 💡 [feat] 지원 서류 삭제 기능
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
- 리크루팅이 끝난 후 지원 서류를 삭제할 수 있도록 api를 추가합니다
  - 최종 발표 전에는 삭제 불가 validation
  - application_answer, application_interview 에는 cascade ALL 옵션 있어서 직접 삭제하는 코드 없어도 함께 삭제됨
  - application_question에 걸려있던 cascade ALL 옵션 삭제 (지원서 질문은 삭제되지 않게)
- CODEOWNERS 파일 업데이트


### 🌲 Working Branch

---
<!-- 예시) feature/user -->
feat/deleteApplication

### 📖 Related Issues

---
<!-- 예시) #1 -->
이슈 번호
- close #176

