### PR TITLE
[fix] 지원자 목록 보기 swagger 에러 수정

### DIFF
--- a/src/main/java/ceos/backend/domain/application/ApplicationController.java
+++ b/src/main/java/ceos/backend/domain/application/ApplicationController.java
@@ -17,6 +17,8 @@ import ceos.backend.domain.application.service.ApplicationExcelService;
 import ceos.backend.domain.application.service.ApplicationService;
 import ceos.backend.global.common.entity.Part;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.nio.file.Path;
@@ -40,8 +42,11 @@ public class ApplicationController {
     @Operation(summary = "지원자 목록 보기")
     @GetMapping
     public GetApplications getApplications(
+            @Parameter(schema = @Schema(allowableValues = {"PRODUCT", "DESIGN", "FRONTEND", "BACKEND"}))
             @RequestParam(value = "part", required = false, defaultValue = "") Part part,
+            @Parameter(schema = @Schema(allowableValues = {"PASS", "FAIL"}))
             @RequestParam(value = "docPass", required = false, defaultValue = "") Pass docPass,
+            @Parameter(schema = @Schema(allowableValues = {"PASS", "FAIL"}))
             @RequestParam(value = "finalPass", required = false, defaultValue = "") Pass finalPass,
             @RequestParam(value = "applicantName", required = false, defaultValue = "") String applicantName,
             @RequestParam("pageNum") int pageNum,

--- a/src/main/java/ceos/backend/domain/application/ApplicationController.java
+++ b/src/main/java/ceos/backend/domain/application/ApplicationController.java
@@ -40,10 +40,10 @@ public class ApplicationController {
     @Operation(summary = "지원자 목록 보기")
     @GetMapping
     public GetApplications getApplications(
-            @RequestParam(value = "part", required = false) Part part,
-            @RequestParam(value = "docPass", required = false) Pass docPass,
-            @RequestParam(value = "finalPass", required = false) Pass finalPass,
-            @RequestParam(value = "applicantName", required = false) String applicantName,
+            @RequestParam(value = "part", required = false, defaultValue = "") Part part,
+            @RequestParam(value = "docPass", required = false, defaultValue = "") Pass docPass,
+            @RequestParam(value = "finalPass", required = false, defaultValue = "") Pass finalPass,
+            @RequestParam(value = "applicantName", required = false, defaultValue = "") String applicantName,
             @RequestParam("pageNum") int pageNum,
             @RequestParam("limit") int limit) {
         log.info("지원자 목록 보기");

--- a/src/test/java/ceos/backend/domain/application/ApplicationControllerTest.java
+++ b/src/test/java/ceos/backend/domain/application/ApplicationControllerTest.java
@@ -23,7 +23,7 @@ public class ApplicationControllerTest {
     @Test
     void getApplicationExcelCreationTime() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/applications/file/creationtime"))
-                .andExpect(MockMvcResultMatchers.status().is(401));
+                .andExpect(MockMvcResultMatchers.status().is(403));
     }
 
     @DisplayName("지원서 목록 보기 API - 필수 아닌 파라미터들 길이 0인 문자열로 처리")

--- a/src/test/java/ceos/backend/domain/application/ApplicationControllerTest.java
+++ b/src/test/java/ceos/backend/domain/application/ApplicationControllerTest.java
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -21,5 +24,27 @@ public class ApplicationControllerTest {
     void getApplicationExcelCreationTime() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/applications/file/creationtime"))
                 .andExpect(MockMvcResultMatchers.status().is(401));
+    }
+
+    @DisplayName("지원서 목록 보기 API - 필수 아닌 파라미터들 길이 0인 문자열로 처리")
+    @Test
+    void getApplicationsWithZeroStrings() throws Exception {
+        Authentication authentication = new TestingAuthenticationToken(null, null, "ROLE_ADMIN");
+
+        mockMvc.perform(MockMvcRequestBuilders
+                        .get("/applications?part=&docPass=&finalPass=&applicantName=&pageNum=0&limit=7")
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(authentication)))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @DisplayName("지원서 목록 보기 API - 필수 아닌 파라미터들 제외")
+    @Test
+    void getApplicationsWithoutRequiredFalse() throws Exception {
+        Authentication authentication = new TestingAuthenticationToken(null, null, "ROLE_ADMIN");
+
+        mockMvc.perform(MockMvcRequestBuilders
+                        .get("/applications?pageNum=0&limit=7")
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(authentication)))
+                .andExpect(MockMvcResultMatchers.status().isOk());
     }
 }

--- a/src/test/java/ceos/backend/domain/application/ApplicationControllerTest.java
+++ b/src/test/java/ceos/backend/domain/application/ApplicationControllerTest.java
@@ -47,4 +47,26 @@ public class ApplicationControllerTest {
                         .with(SecurityMockMvcRequestPostProcessors.authentication(authentication)))
                 .andExpect(MockMvcResultMatchers.status().isOk());
     }
+
+    @DisplayName("지원서 목록 보기 API - enum 타입 영어로 처리")
+    @Test
+    void successGetApplications() throws Exception {
+        Authentication authentication = new TestingAuthenticationToken(null, null, "ROLE_ADMIN");
+
+        mockMvc.perform(MockMvcRequestBuilders
+                        .get("/applications?part=PRODUCT&docPass=PASS&finalPass=FAIL&applicantName=&pageNum=0&limit=7")
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(authentication)))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @DisplayName("지원서 목록 보기 API - enum 타입 한글로 처리 시 예외 발생")
+    @Test
+    void failGetApplications() throws Exception {
+        Authentication authentication = new TestingAuthenticationToken(null, null, "ROLE_ADMIN");
+
+        mockMvc.perform(MockMvcRequestBuilders
+                        .get("/applications?part=기획&docPass=합격&finalPass=불합격&applicantName=&pageNum=0&limit=7")
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(authentication)))
+                .andExpect(MockMvcResultMatchers.status().is(400));
+    }
 }


### PR DESCRIPTION
# 💡 [fix] 지원자 목록 보기 swagger 에러 수정
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
- 지원자 목록 보기에 해당하는 api를 swagger에서 실행할 경우, 특정 조건들에서 에러가 발생하고 있어 관련 설정을 추가하였습니다.
  - required false인 파라미터들에 대해 값이 들어오지 않을 경우, 길이가 0인 문자열이 들어가도록 default value 설정
  - enum 타입인 파라미터들에 대해 값이 한글로 들어가고 있어 영어로 들어가도록 allowable values 설정
  - 설정 추가라 feat 커밋이라고 생각했는데 pr 올리려고보니 fix가 더 맞는 것 같네요...ㅠㅠㅠ

- 수정한 부분들에 대한 테스트 코드를 작성했습니다.
  - 400 bad request가 뜨던 부분들을 고친거라 수정한 코드들이 200 ok가 나오는지를 위주로 테스트했습니다.

+) 인텔리제이 오류가 있어 dev 브랜치에 바로 푸시하는 이슈가 있었습니다 다음에 더 주의하도록 하겠습니다... dev 브랜치 코드는 되돌려놓았습니다...

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
feat/getApplications

### 📖 Related Issues

---
<!-- 예시) #1 -->
- close #178 

