### PR TITLE
[refact] 회고 기능 response dto 필드 정리

### DIFF
--- a/src/main/java/ceos/backend/domain/retrospect/dto/response/GetRetrospectResponse.java
+++ b/src/main/java/ceos/backend/domain/retrospect/dto/response/GetRetrospectResponse.java
@@ -10,6 +10,8 @@ public class GetRetrospectResponse {
     private String title;
     private String url;
     private String writer;
+    private Integer generation;
+    private String part;
 
     public static GetRetrospectResponse fromEntity(Retrospect retrospect) {
         GetRetrospectResponse getRetrospectResponse = new GetRetrospectResponse();
@@ -18,6 +20,8 @@ public class GetRetrospectResponse {
         getRetrospectResponse.setTitle(retrospect.getTitle());
         getRetrospectResponse.setUrl(retrospect.getUrl());
         getRetrospectResponse.setWriter(retrospect.getWriter());
+        getRetrospectResponse.setGeneration(retrospect.getGeneration());
+        getRetrospectResponse.setPart(retrospect.getPart().getPart());
 
         return getRetrospectResponse;
     }

--- a/src/main/java/ceos/backend/domain/retrospect/dto/response/GetRetrospectsElement.java
+++ b/src/main/java/ceos/backend/domain/retrospect/dto/response/GetRetrospectsElement.java
@@ -10,16 +10,14 @@ import lombok.Data;
 public class GetRetrospectsElement {
     private Long id;
     private String title;
-    private String url;
-    private String writer;
     private Integer generation;
+    private String part;
 
     public static GetRetrospectsElement fromEntity(Retrospect retrospect) {
         return new GetRetrospectsElement(
                 retrospect.getId(),
                 retrospect.getTitle(),
-                retrospect.getUrl(),
-                retrospect.getWriter(),
-                retrospect.getGeneration());
+                retrospect.getGeneration(),
+                retrospect.getPart().getPart());
     }
 }


### PR DESCRIPTION
# 💡 PR Summary - 회고 기능 response dto 필드 정리
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
회고록 목록 보기 api와 회고록 상세 보기/수정 api에 사용되는 response dto의 필드에 다소 아쉬운 부분이 있어 수정 진행

 1. 회고록 목록 보기 api response dto 필드 수정 (제목, url, 작성자, 활동기수 -> 제목, 활동기수, 파트)
 2. 회고록 상세 보기/수정 api response 필드 수정 (제목, url, 작성자 -> 제목, url, 작성자, 활동기수, 파트)

-> 회고록 작성 api에서는 입력하지만 사용되지 않았던 파트를 dto에 추가하고 "상세 보기"라는 api 이름에 맞게 상세 보기 api에서 더 자세한 회고록 정보를 확인할 수 있도록 수정

세오스 프로젝트 페이지를 보면 목록 보기에서는 프로젝트 이름, 기수, 한줄소개를 보여주고 있어 회고록 목록 보기 dto도 비슷한 느낌으로 수정하였습니다. 

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
refact/retrospect

### 📖 Related Issues

---
<!-- 예시) #1 -->
- close #183 

